### PR TITLE
Making select test having randomized payload

### DIFF
--- a/test/basic_tests.cpp
+++ b/test/basic_tests.cpp
@@ -1,5 +1,4 @@
 #include "test_base.h"
-#include "gtest/gtest.h"
 
 TEST(MathOpTests, IAddOpTest) { iadd_test(); }
 TEST(MathOpTests, FAddOpTest) { fadd_test(); }

--- a/test/test_base.cpp
+++ b/test/test_base.cpp
@@ -9,19 +9,8 @@
 #include "tilt/builder/tilder.h"
 #include "tilt/codegen/vinstr.h"
 
-#include "gtest/gtest.h"
-
 using namespace tilt;
 using namespace tilt::tilder;
-
-template<typename T>
-void assert_eq(T exp, T act) { ASSERT_EQ(exp, act); }
-
-template<>
-void assert_eq(float exp, float act) { ASSERT_FLOAT_EQ(exp, act); }
-
-template<>
-void assert_eq(double exp, double act) { ASSERT_DOUBLE_EQ(exp, act); }
 
 void run_op(Op op, ts_t st, ts_t et, region_t* out_reg, region_t* in_reg)
 {

--- a/test/test_base.h
+++ b/test/test_base.h
@@ -6,6 +6,8 @@
 
 #include "tilt/ir/op.h"
 
+#include "gtest/gtest.h"
+
 using namespace std;
 using namespace tilt;
 
@@ -24,6 +26,19 @@ void op_test(Op, QueryFn<InTy, OutTy>, vector<Event<InTy>>);
 
 template<typename InTy, typename OutTy>
 void select_test(function<Expr(Expr)>, function<OutTy(InTy)>);
+
+namespace {
+
+template<typename T>
+void assert_eq(T exp, T act) { ASSERT_EQ(exp, act); }
+
+template<>
+void assert_eq(float exp, float act) { ASSERT_FLOAT_EQ(exp, act); }
+
+template<>
+void assert_eq(double exp, double act) { ASSERT_DOUBLE_EQ(exp, act); }
+
+}  // namespace
 
 // Math ops tests
 void iadd_test();


### PR DESCRIPTION
The payload for the select test events will now have randomly assigned value each run instead of statically assigned value.