### PR TITLE
Exec Engine Register Struct Types

### DIFF
--- a/include/tilt/codegen/llvmgen.h
+++ b/include/tilt/codegen/llvmgen.h
@@ -36,11 +36,10 @@ public:
         IRGen(move(llgenctx)), _llctx(*llgenctx.llctx),
         _llmod(make_unique<llvm::Module>(llgenctx.loop->name, _llctx)),
         _builder(make_unique<llvm::IRBuilder<>>(_llctx))
-    {
-        register_vinstrs();
-    }
+    {}
 
     static unique_ptr<llvm::Module> Build(const Looper, llvm::LLVMContext&);
+    void register_vinstrs();
 
 private:
     llvm::Value* visit(const Symbol&) final;
@@ -74,8 +73,6 @@ private:
         IRGen::assign(sym_ptr, val);
         val->setName(sym_ptr->name);
     }
-
-    void register_vinstrs();
 
     llvm::Function* llfunc(const string, llvm::Type*, vector<llvm::Type*>);
     llvm::Value* llcall(const string, llvm::Type*, vector<llvm::Value*>);

--- a/include/tilt/engine/engine.h
+++ b/include/tilt/engine/engine.h
@@ -39,7 +39,7 @@ public:
         jd(es.createBareJITDylib("__tilt_dylib"))
     {
         jd.addGenerator(cantFail(DynamicLibrarySearchGenerator::GetForCurrentProcess(dl.getGlobalPrefix())));
-        register_vinstrs();
+        register_struct_types();
     }
 
     static ExecEngine* Get();
@@ -47,9 +47,10 @@ public:
     LLVMContext& GetCtx();
     Module* llmod() { return _llmod.get(); }
     intptr_t Lookup(StringRef);
-    void register_vinstrs();
 
 private:
+    void register_struct_types();
+    
     static Expected<ThreadSafeModule> optimize_module(ThreadSafeModule, const MaterializationResponsibility&);
 
     ExecutionSession es;

--- a/src/codegen/llvmgen.cpp
+++ b/src/codegen/llvmgen.cpp
@@ -516,5 +516,6 @@ unique_ptr<llvm::Module> LLVMGen::Build(const Looper loop, llvm::LLVMContext& ll
     LLVMGenCtx ctx(loop.get(), &llctx);
     LLVMGen llgen(move(ctx));
     loop->Accept(llgen);
+    llgen.register_vinstrs();
     return move(llgen._llmod);
 }

--- a/src/codegen/vinstr.cpp
+++ b/src/codegen/vinstr.cpp
@@ -74,27 +74,17 @@ region_t* commit_null(region_t* reg, ts_t t)
     return reg;
 }
 
+void register_types(region_t* reg, ival_t* tl){}
+
 }  // extern "C"
 
-void ExecEngine::register_vinstrs()
+void ExecEngine::register_struct_types()
 {
-    llvm::Linker::linkModules(*llmod(), easy::get_module(GetCtx(), get_start_idx, _1));
-    llvm::Linker::linkModules(*llmod(), easy::get_module(GetCtx(), get_end_idx, _1));
-    llvm::Linker::linkModules(*llmod(), easy::get_module(GetCtx(), get_ckpt, _1, _2, _3));
-    llvm::Linker::linkModules(*llmod(), easy::get_module(GetCtx(), advance, _1, _2, _3));
-    llvm::Linker::linkModules(*llmod(), easy::get_module(GetCtx(), fetch, _1, _2, _3, _4));
-    llvm::Linker::linkModules(*llmod(), easy::get_module(GetCtx(), make_region, _1, _2, _3, _4, _5, _6));
-    llvm::Linker::linkModules(*llmod(), easy::get_module(GetCtx(), init_region, _1, _2, _3, _4));
-    llvm::Linker::linkModules(*llmod(), easy::get_module(GetCtx(), commit_data, _1, _2));
-    llvm::Linker::linkModules(*llmod(), easy::get_module(GetCtx(), commit_null, _1, _2));
+    easy::get_module(GetCtx(), register_types, _1, _2);
 }
 
 void LLVMGen::register_vinstrs()
 {
-    auto type_region = llmod()->getTypeByName("struct.region_t");
-    auto type_ival = llmod()->getTypeByName("struct.ival_t");
-    new llvm::GlobalVariable(*llmod(), type_region, false, llvm::GlobalVariable::CommonLinkage, llvm::Constant::getNullValue(type_region), "1");
-    new llvm::GlobalVariable(*llmod(), type_ival, false, llvm::GlobalVariable::CommonLinkage, llvm::Constant::getNullValue(type_ival), "2");
     llvm::Linker::linkModules(*llmod(), easy::get_module(llctx(), get_start_idx, _1));
     llvm::Linker::linkModules(*llmod(), easy::get_module(llctx(), get_end_idx, _1));
     llvm::Linker::linkModules(*llmod(), easy::get_module(llctx(), get_ckpt, _1, _2, _3));


### PR DESCRIPTION
Use Exec Engine to register the struct types. Each LLVMGen instance will generate the loop query before registering for virtual instructions using easy::jit. And the struct types will be retrieved from the llvmctx of the exec-engine. 

This prevents the issue that the loop query might use duplicated struct types (such as `struct.region_t.1` instead of `struct.region_t`) generated by easy::jit because of re-registering the same struct types. 