### PR TITLE
Changed time type from unsigned to signed

### DIFF
--- a/tilt/include/tilt/base/type.h
+++ b/tilt/include/tilt/base/type.h
@@ -90,7 +90,8 @@ struct DataType {
             || (this->btype == BaseType::INT32)
             || (this->btype == BaseType::INT64)
             || (this->btype == BaseType::FLOAT32)
-            || (this->btype == BaseType::FLOAT64);
+            || (this->btype == BaseType::FLOAT64)
+            || (this->btype == BaseType::TIME);
     }
 
     DataType ptr() const { return DataType(BaseType::PTR, {*this}); }


### PR DESCRIPTION
Time is defined from -infinity to +infinity, so it should be a signed type.