### PR TITLE
find region_t parameters explicitly when adding noalias attribute

### DIFF
--- a/include/tilt/pass/codegen/llvmgen.h
+++ b/include/tilt/pass/codegen/llvmgen.h
@@ -95,6 +95,9 @@ private:
     llvm::Type* lltype(const ExprNode& expr) { return lltype(expr.type); }
     llvm::Type* lltype(const Expr& expr) { return lltype(expr->type); }
 
+    llvm::Type* llregtype() { return llmod()->getTypeByName("struct.region_t"); }
+    llvm::Type* llregptrtype() { return llvm::PointerType::get(llregtype(), 0); }
+
     llvm::Module* llmod() { return _llmod.get(); }
     llvm::LLVMContext& llctx() { return _llctx; }
     llvm::IRBuilder<>* builder() { return _builder.get(); }

--- a/src/pass/codegen/llvmgen.cpp
+++ b/src/pass/codegen/llvmgen.cpp
@@ -462,9 +462,9 @@ Value* LLVMGen::visit(const LoopNode& loop)
         set_expr(input, loop_fn->getArg(i));
     }
     // We add `noalias` attribute to the region parameters to help compiler autovectorize
-    const auto* regtype = llregptrtype();
     for (size_t i = 0; i < loop.inputs.size(); i++) {
-        if (args_type[i] == regtype) {
+        // If type is not a value, then it should be a region
+        if (!loop.inputs[i]->type.is_val()) {
             loop_fn->addParamAttr(i, Attribute::NoAlias);
         }
     }


### PR DESCRIPTION
`region_t` parameters don't always start at index 2, so check all the param types explicitly and add no alias