### PR TITLE
Upgraded to LLVM 15.0.7

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -14,10 +14,17 @@ jobs:
     # You can convert this to a matrix build if you need cross-platform coverage.
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
     
-    # We use Ubuntu 20.04 so we have access to LLVM 11 dependency
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
+    - name: Install LLVM and Clang
+      run: |
+        wget https://apt.llvm.org/llvm.sh
+        chmod +x llvm.sh
+        sudo ./llvm.sh 15
+        sudo ln -f /usr/bin/clang-15 /usr/bin/clang
+        sudo ln -f /usr/bin/clang++-15 /usr/bin/clang++
+
     - uses: actions/checkout@v3
       with:
         submodules: true
@@ -36,4 +43,3 @@ jobs:
       # Execute tests defined by the CMake configuration.
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
       run: ctest -C ${{env.BUILD_TYPE}}
-

--- a/include/tilt/base/type.h
+++ b/include/tilt/base/type.h
@@ -158,10 +158,10 @@ struct Type {
     const Iter iter;
 
     Type(DataType dtype, Iter iter) :
-        dtype(move(dtype)), iter(iter)
+        dtype(std::move(dtype)), iter(iter)
     {}
 
-    explicit Type(DataType dtype) : Type(move(dtype), Iter()) {}
+    explicit Type(DataType dtype) : Type(std::move(dtype), Iter()) {}
 
     bool is_val() const { return iter.period == 0; }
     bool is_beat() const { return iter.period > 0 && dtype.btype == BaseType::TIME; }

--- a/include/tilt/builder/tilder.h
+++ b/include/tilt/builder/tilder.h
@@ -35,7 +35,7 @@ _expr<SubLStream> _expr_subls(Sym, Window);
 
 template<typename T>
 struct _expr : public shared_ptr<T> {
-    explicit _expr(shared_ptr<T>&& ptr) : shared_ptr<T>(move(ptr)) {}
+    explicit _expr(shared_ptr<T>&& ptr) : shared_ptr<T>(std::move(ptr)) {}
 
     _expr<Add> operator+(Expr o) const { return _expr_add(*this, o); }
     _expr<Sub> operator-(Expr o) const { return _expr_sub(*this, o); }
@@ -84,7 +84,7 @@ struct _beat : public _expr<Beat> {
     template<typename... Args> \
     struct NAME : public _expr<EXPR> { \
         explicit NAME(Args... args) : \
-            _expr<EXPR>(move(make_shared<EXPR>(forward<Args>(args)...))) \
+            _expr<EXPR>(std::move(make_shared<EXPR>(std::forward<Args>(args)...))) \
         {} \
     };
 

--- a/include/tilt/engine/engine.h
+++ b/include/tilt/engine/engine.h
@@ -31,9 +31,9 @@ class ExecEngine {
 public:
     ExecEngine(JITTargetMachineBuilder jtmb, DataLayout dl) :
         linker(es, []() { return make_unique<SectionMemoryManager>(); }),
-        compiler(es, linker, make_unique<ConcurrentIRCompiler>(move(jtmb))),
+        compiler(es, linker, make_unique<ConcurrentIRCompiler>(std::move(jtmb))),
         optimizer(es, compiler, optimize_module),
-        dl(move(dl)), mangler(es, this->dl),
+        dl(std::move(dl)), mangler(es, this->dl),
         ctx(make_unique<LLVMContext>()),
         jd(es.createBareJITDylib("__tilt_dylib"))
     {

--- a/include/tilt/engine/engine.h
+++ b/include/tilt/engine/engine.h
@@ -30,12 +30,13 @@ namespace tilt {
 class ExecEngine {
 public:
     ExecEngine(JITTargetMachineBuilder jtmb, DataLayout dl) :
-        linker(es, []() { return make_unique<SectionMemoryManager>(); }),
-        compiler(es, linker, make_unique<ConcurrentIRCompiler>(std::move(jtmb))),
-        optimizer(es, compiler, optimize_module),
-        dl(std::move(dl)), mangler(es, this->dl),
+        es(createExecutionSession()),
+        linker(*es, []() { return make_unique<SectionMemoryManager>(); }),
+        compiler(*es, linker, make_unique<ConcurrentIRCompiler>(std::move(jtmb))),
+        optimizer(*es, compiler, optimize_module),
+        dl(std::move(dl)), mangler(*es, this->dl),
         ctx(make_unique<LLVMContext>()),
-        jd(es.createBareJITDylib("__tilt_dylib"))
+        jd(es->createBareJITDylib("__tilt_dylib"))
     {
         jd.addGenerator(cantFail(DynamicLibrarySearchGenerator::GetForCurrentProcess(dl.getGlobalPrefix())));
     }
@@ -47,8 +48,9 @@ public:
 
 private:
     static Expected<ThreadSafeModule> optimize_module(ThreadSafeModule, const MaterializationResponsibility&);
+    static unique_ptr<ExecutionSession> createExecutionSession();
 
-    ExecutionSession es;
+    unique_ptr<ExecutionSession> es;
     RTDyldObjectLinkingLayer linker;
     IRCompileLayer compiler;
     IRTransformLayer optimizer;

--- a/include/tilt/ir/expr.h
+++ b/include/tilt/ir/expr.h
@@ -20,7 +20,7 @@ struct Call : public ExprNode {
     vector<Expr> args;
 
     Call(string name, Type type, vector<Expr> args) :
-        ExprNode(type), name(name), args(move(args))
+        ExprNode(type), name(name), args(std::move(args))
     {}
 
     void Accept(Visitor&) const final;
@@ -109,7 +109,7 @@ struct NaryExpr : public ValNode {
     vector<Expr> args;
 
     NaryExpr(DataType dtype, MathOp op, vector<Expr> args) :
-        ValNode(dtype), op(op), args(move(args))
+        ValNode(dtype), op(op), args(std::move(args))
     {
         ASSERT(!arg(0)->type.dtype.is_ptr() && !arg(0)->type.dtype.is_struct());
     }

--- a/include/tilt/ir/loop.h
+++ b/include/tilt/ir/loop.h
@@ -232,7 +232,7 @@ struct LoopNode : public FuncNode {
     // Inner loops
     vector<shared_ptr<LoopNode>> inner_loops;
 
-    LoopNode(string name, Type type) : FuncNode(name, move(type)) {}
+    LoopNode(string name, Type type) : FuncNode(name, std::move(type)) {}
     explicit LoopNode(Sym sym) : LoopNode(sym->name, sym->type) {}
 
     const string get_name() const override { return "loop_" + this->name; }

--- a/include/tilt/ir/lstream.h
+++ b/include/tilt/ir/lstream.h
@@ -11,7 +11,7 @@ using namespace std;
 namespace tilt {
 
 struct LStream : public ExprNode {
-    explicit LStream(Type type) : ExprNode(move(type)) { ASSERT(!this->type.is_val()); }
+    explicit LStream(Type type) : ExprNode(std::move(type)) { ASSERT(!this->type.is_val()); }
 };
 
 struct Out : public Symbol {

--- a/include/tilt/ir/node.h
+++ b/include/tilt/ir/node.h
@@ -48,13 +48,13 @@ struct FuncNode : public ExprNode {
     SymTable syms;
 
     FuncNode(string name, Params inputs, Sym output, SymTable syms) :
-        ExprNode(output->type), name(name), inputs(move(inputs)), output(output), syms(move(syms))
+        ExprNode(output->type), name(name), inputs(std::move(inputs)), output(output), syms(std::move(syms))
     {}
 
     virtual const string get_name() const = 0;
 
 protected:
-    FuncNode(string name, Type type) : ExprNode(move(type)), name(name) {}
+    FuncNode(string name, Type type) : ExprNode(std::move(type)), name(name) {}
 };
 typedef shared_ptr<FuncNode> Func;
 

--- a/include/tilt/ir/op.h
+++ b/include/tilt/ir/op.h
@@ -23,7 +23,7 @@ struct OpNode : public LStream {
 
     OpNode(Iter iter, Params inputs, SymTable syms, Expr pred, Sym output, Aux aux = {}) :
         LStream(Type(output->type.dtype, iter)), iter(iter),
-        inputs(move(inputs)), syms(move(syms)), pred(pred), output(output), aux(move(aux))
+        inputs(std::move(inputs)), syms(std::move(syms)), pred(pred), output(output), aux(std::move(aux))
     {}
 
     void Accept(Visitor&) const final;

--- a/include/tilt/pass/codegen/llvmgen.h
+++ b/include/tilt/pass/codegen/llvmgen.h
@@ -42,7 +42,7 @@ private:
 class LLVMGen : public IRGen<LLVMGenCtx, Expr, llvm::Value*> {
 public:
     explicit LLVMGen(LLVMGenCtx llgenctx) :
-        _ctx(move(llgenctx)), _llctx(*ctx().llctx),
+        _ctx(std::move(llgenctx)), _llctx(*ctx().llctx),
         _llmod(make_unique<llvm::Module>(ctx().loop->name, _llctx)),
         _builder(make_unique<llvm::IRBuilder<>>(_llctx))
     {

--- a/include/tilt/pass/codegen/llvmgen.h
+++ b/include/tilt/pass/codegen/llvmgen.h
@@ -104,7 +104,7 @@ private:
     llvm::Type* lltype(const ExprNode& expr) { return lltype(expr.type); }
     llvm::Type* lltype(const Expr& expr) { return lltype(expr->type); }
 
-    llvm::Type* llregtype() { return llmod()->getTypeByName("struct.region_t"); }
+    llvm::Type* llregtype() { return llvm::StructType::getTypeByName(llctx(), "struct.region_t"); }
     llvm::Type* llregptrtype() { return llvm::PointerType::get(llregtype(), 0); }
 
     llvm::Module* llmod() { return _llmod.get(); }

--- a/include/tilt/pass/codegen/loopgen.h
+++ b/include/tilt/pass/codegen/loopgen.h
@@ -29,7 +29,7 @@ private:
 
 class LoopGen : public IRGen<LoopGenCtx, Expr, Expr> {
 public:
-    explicit LoopGen(LoopGenCtx ctx) : _ctx(move(ctx)) {}
+    explicit LoopGen(LoopGenCtx ctx) : _ctx(std::move(ctx)) {}
 
     static Loop Build(Sym, const OpNode*);
 

--- a/include/tilt/pass/printer.h
+++ b/include/tilt/pass/printer.h
@@ -27,10 +27,10 @@ private:
 class IRPrinter : public Visitor {
 public:
     IRPrinter() : IRPrinter(IRPrinterCtx()) {}
-    explicit IRPrinter(IRPrinterCtx ctx) : IRPrinter(move(ctx), 2) {}
+    explicit IRPrinter(IRPrinterCtx ctx) : IRPrinter(std::move(ctx), 2) {}
 
     IRPrinter(IRPrinterCtx ctx, size_t tabstop) :
-        ctx(move(ctx)), tabstop(tabstop)
+        ctx(std::move(ctx)), tabstop(tabstop)
     {}
 
     static string Build(const Expr);

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,7 +8,7 @@ set(SRC_FILES
     engine/engine.cpp
 )
 
-find_package(LLVM 11.0.0 REQUIRED CONFIG)
+find_package(LLVM 15 REQUIRED CONFIG)
 message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
 message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
 

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -16,7 +16,7 @@ ExecEngine* ExecEngine::Get()
         auto jtmb = cantFail(JITTargetMachineBuilder::detectHost());
         auto dl = cantFail(jtmb.getDefaultDataLayoutForTarget());
 
-        engine = make_unique<ExecEngine>(move(jtmb), move(dl));
+        engine = make_unique<ExecEngine>(std::move(jtmb), std::move(dl));
     }
 
     return engine.get();
@@ -27,7 +27,7 @@ void ExecEngine::AddModule(unique_ptr<Module> m)
     raw_fd_ostream r(fileno(stdout), false);
     verifyModule(*m, &r);
 
-    cantFail(optimizer.add(jd, ThreadSafeModule(move(m), ctx)));
+    cantFail(optimizer.add(jd, ThreadSafeModule(std::move(m), ctx)));
 }
 
 LLVMContext& ExecEngine::GetCtx() { return *ctx.getContext(); }
@@ -53,5 +53,5 @@ Expected<ThreadSafeModule> ExecEngine::optimize_module(ThreadSafeModule tsm, con
         mpm.run(m);
     });
 
-    return move(tsm);
+    return std::move(tsm);
 }

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -1,4 +1,5 @@
 #include "llvm/IR/Verifier.h"
+#include "llvm/ExecutionEngine/Orc/ExecutorProcessControl.h"
 
 #include "tilt/engine/engine.h"
 
@@ -34,7 +35,7 @@ LLVMContext& ExecEngine::GetCtx() { return *ctx.getContext(); }
 
 intptr_t ExecEngine::Lookup(StringRef name)
 {
-    auto fn_sym = cantFail(es.lookup({ &jd }, mangler(name.str())));
+    auto fn_sym = cantFail(es->lookup({ &jd }, mangler(name.str())));
     return (intptr_t) fn_sym.getAddress();
 }
 
@@ -54,4 +55,9 @@ Expected<ThreadSafeModule> ExecEngine::optimize_module(ThreadSafeModule tsm, con
     });
 
     return std::move(tsm);
+}
+
+unique_ptr<ExecutionSession> ExecEngine::createExecutionSession() {
+    unique_ptr<SelfExecutorProcessControl> epc = llvm::cantFail(SelfExecutorProcessControl::Create());
+    return std::make_unique<ExecutionSession>(std::move(epc));
 }

--- a/src/pass/codegen/llvmgen.cpp
+++ b/src/pass/codegen/llvmgen.cpp
@@ -528,9 +528,9 @@ Value* LLVMGen::visit(const LoopNode& loop)
 unique_ptr<llvm::Module> LLVMGen::Build(const Loop loop, llvm::LLVMContext& llctx)
 {
     LLVMGenCtx ctx(loop.get(), &llctx);
-    LLVMGen llgen(move(ctx));
+    LLVMGen llgen(std::move(ctx));
     loop->Accept(llgen);
-    return move(llgen._llmod);
+    return std::move(llgen._llmod);
 }
 
 void LLVMGen::register_vinstrs() {
@@ -557,7 +557,7 @@ void LLVMGen::register_vinstrs() {
         vinstr_names.push_back(function.getName().str());
     }
 
-    llvm::Linker::linkModules(*llmod(), move(vinstr_mod));
+    llvm::Linker::linkModules(*llmod(), std::move(vinstr_mod));
     for (const auto& name : vinstr_names) {
         llmod()->getFunction(name.c_str())->setLinkage(llvm::Function::InternalLinkage);
     }

--- a/src/pass/codegen/loopgen.cpp
+++ b/src/pass/codegen/loopgen.cpp
@@ -192,7 +192,7 @@ Expr LoopGen::visit(const Call& call)
     for (const auto& arg : call.args) {
         args.push_back(eval(arg));
     }
-    return _call(call.name, call.type, move(args));
+    return _call(call.name, call.type, std::move(args));
 }
 
 Expr LoopGen::visit(const Exists& exists)
@@ -221,7 +221,7 @@ Expr LoopGen::visit(const New& new_expr)
     for (const auto& input : new_expr.inputs) {
         input_vals.push_back(eval(input));
     }
-    return _new(move(input_vals));
+    return _new(std::move(input_vals));
 }
 
 Expr LoopGen::visit(const Get& get) { return _get(eval(get.input), get.n); }
@@ -236,7 +236,7 @@ Expr LoopGen::visit(const NaryExpr& e)
     for (auto arg : e.args) {
         args.push_back(eval(arg));
     }
-    return make_shared<NaryExpr>(e.type.dtype, e.op, move(args));
+    return make_shared<NaryExpr>(e.type.dtype, e.op, std::move(args));
 }
 
 Expr LoopGen::visit(const SubLStream& subls)
@@ -319,7 +319,7 @@ Expr LoopGen::visit(const OpNode& op)
     for (const auto& input : inputs) {
         args.push_back(input);
     }
-    return _call(inner_loop->get_name(), inner_loop->type, move(args));
+    return _call(inner_loop->get_name(), inner_loop->type, std::move(args));
 }
 
 Expr LoopGen::visit(const Reduce& red)
@@ -371,7 +371,7 @@ Loop LoopGen::Build(Sym sym, const OpNode* op)
 {
     auto loop = _loop(sym);
     LoopGenCtx ctx(sym, op, loop);
-    LoopGen loopgen(move(ctx));
+    LoopGen loopgen(std::move(ctx));
     loopgen.build_loop();
     return loopgen.ctx().loop;
 }

--- a/test/src/test_base.cpp
+++ b/test/src/test_base.cpp
@@ -23,7 +23,7 @@ void run_op(string query_name, Op op, ts_t st, ts_t et, region_t* out_reg, regio
     auto& llctx = jit->GetCtx();
 
     auto llmod = LLVMGen::Build(loop, llctx);
-    jit->AddModule(move(llmod));
+    jit->AddModule(std::move(llmod));
 
     auto loop_addr = (region_t* (*)(ts_t, ts_t, region_t*, region_t*)) jit->Lookup(loop->get_name());
 
@@ -102,7 +102,7 @@ void select_test(string query_name, function<Expr(Expr)> sel_expr, function<OutT
             out.push_back({in[i].st, in[i].et, sel_fn(in[i].payload)});
         }
 
-        return move(out);
+        return std::move(out);
     };
 
     unary_op_test<InTy, OutTy>(query_name, sel_op, 0, len * dur, sel_query_fn, len, dur);
@@ -293,7 +293,7 @@ void moving_sum_test()
             out[i] = {in[i].st, in[i].et, payload};
         }
 
-        return move(out);
+        return std::move(out);
     };
 
     unary_op_test<int32_t, int32_t>("moving_sum", mov_op, 0, len * dur, mov_query_fn, len, dur);
@@ -331,7 +331,7 @@ void norm_test()
             }
         }
 
-        return move(out);
+        return std::move(out);
     };
 
     unary_op_test<float, float>("norm", norm_op, 0, len * dur, norm_query_fn, len, dur);
@@ -361,7 +361,7 @@ void run_resample(string query_name, int64_t iperiod, int64_t operiod)
             }
         }
 
-        return move(out);
+        return std::move(out);
     };
 
     unary_op_test<float, float>(query_name, resample_op, 0, len * dur, resample_query_fn, len, dur);


### PR DESCRIPTION
I also had to change `move` to `std::move` and `forward` to `std::forward`. Details here https://reviews.llvm.org/D119670?id=408276

I also tried upgrading to LLVM 16 but ran into some weird segfault issues, but didn't look into it too much. For now I'll just stuck with LLVM 15.
```
test 16
      Start 16: QuiltTest.NormTest

16: Test command: /home/song/workspace/tilt/build/test/tilt_test "--gtest_filter=QuiltTest.NormTest" "--gtest_also_run_disabled_tests"
16: Test timeout computed to be: 10000000
16: Running main() from /home/song/workspace/tilt/third_party/googletest/googletest/src/gtest_main.cc
16: Note: Google Test filter = QuiltTest.NormTest
16: [==========] Running 1 test from 1 test suite.
16: [----------] Global test environment set-up.
16: [----------] 1 test from QuiltTest
16: [ RUN      ] QuiltTest.NormTest
16: warning: <unknown>:0:0: stack frame size (1099511627768) exceeds limit (4294967295) in function 'loop_norm'
16: 180/1099511627768 (0.00%) spills, 1099511627588/1099511627768 (100.00%) variables
16/17 Test #16: QuiltTest.NormTest ...............***Exception: SegFault  0.30 sec
test 17
      Start 17: QuiltTest.ResampleTest

17: Test command: /home/song/workspace/tilt/build/test/tilt_test "--gtest_filter=QuiltTest.ResampleTest" "--gtest_also_run_disabled_tests"
17: Test timeout computed to be: 10000000
17: Running main() from /home/song/workspace/tilt/third_party/googletest/googletest/src/gtest_main.cc
17: Note: Google Test filter = QuiltTest.ResampleTest
17: [==========] Running 1 test from 1 test suite.
17: [----------] Global test environment set-up.
17: [----------] 1 test from QuiltTest
17: [ RUN      ] QuiltTest.ResampleTest
17/17 Test #17: QuiltTest.ResampleTest ...........***Exception: SegFault  0.33 sec

88% tests passed, 2 tests failed out of 17

Total Test time (real) =   1.55 sec

The following tests FAILED:
         16 - QuiltTest.NormTest (SEGFAULT)
         17 - QuiltTest.ResampleTest (SEGFAULT)
Errors while running CTest
```