### PR TITLE
Change bool type from Int1 to Int8

### DIFF
--- a/src/pass/codegen/llvmgen.cpp
+++ b/src/pass/codegen/llvmgen.cpp
@@ -46,7 +46,7 @@ llvm::Type* LLVMGen::lltype(const DataType& dtype)
 {
     switch (dtype.btype) {
         case BaseType::BOOL:
-            return llvm::Type::getInt1Ty(llctx());
+            return llvm::Type::getInt8Ty(llctx());
         case BaseType::INT8:
         case BaseType::UINT8:
             return llvm::Type::getInt8Ty(llctx());


### PR DESCRIPTION
This change does introduce warning messages in our llvm code though
```
Branch condition is not 'i1' type!
  br i8 1, label %then, label %else
```